### PR TITLE
Add gitignore for IntelliJ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.iml
+.idea/
+out/
+*.jar
+*.class


### PR DESCRIPTION
A `.gitignore` file tells git to ignore certain file types and directories. This specific one ignores IntelliJ project files (`.iml` and the `.idea/` folder) and compiler output (`out/`, `.jar`, and `.class`), which may make adding changes to git easier later on.
